### PR TITLE
[JENKNIS-60770] provide alternative echars versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Then you can use ECharts in your jelly files using the following snippet:
 ```xml
 <st:adjunct includes="io.jenkins.plugins.echarts"/>
 ```
+If you don't need all charts, you can also use one of
+```xml
+<st:adjunct includes="io.jenkins.plugins.echarts-common"/>
+<st:adjunct includes="io.jenkins.plugins.echarts-simple"/>
+```
+which provide smaller .js files, but also fewer charts. See the [echarts documentation](https://echarts.apache.org/en/tutorial.html#Create%20Custom%20Build%20of%20ECharts)
+for more information.
  
 You can find several examples of Jenkins views that use ECharts in the 
 [Warnings Next Generation plugin](https://github.com/jenkinsci/warnings-ng-plugin).

--- a/src/main/resources/io/jenkins/plugins/echarts-common.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts-common.jelly
@@ -1,13 +1,13 @@
 <?jelly escape-by-default='true'?>
 <!--
-Use it like <st:adjunct includes="io.jenkins.plugins.echarts"/>
+Use it like <st:adjunct includes="io.jenkins.plugins.echarts-common"/>
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 
   <j:new var="h" className="hudson.Functions" />
   ${h.initPageVariables(context)}
 
-  <script type="text/javascript" src="${resURL}/plugin/echarts-api/webjars/echarts-en.min.js" />
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/webjars/echarts-en.common.min.js" />
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 

--- a/src/main/resources/io/jenkins/plugins/echarts-simple.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts-simple.jelly
@@ -1,13 +1,13 @@
 <?jelly escape-by-default='true'?>
 <!--
-Use it like <st:adjunct includes="io.jenkins.plugins.echarts"/>
+Use it like <st:adjunct includes="io.jenkins.plugins.echarts-simple"/>
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 
   <j:new var="h" className="hudson.Functions" />
   ${h.initPageVariables(context)}
 
-  <script type="text/javascript" src="${resURL}/plugin/echarts-api/webjars/echarts-en.min.js" />
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/webjars/echarts-en.simple.min.js" />
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 


### PR DESCRIPTION
Include alternative echarts versions, which provide smaller files but also fewer available graphs.

See [JENKINS-60770](https://issues.jenkins-ci.org/browse/JENKINS-60770) for more information.