### PR TITLE
Use common parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>2.0.0-beta-2</version>
+    <version>2.0.0</version>
     <relativePath/>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,19 +14,17 @@
   <name>ECharts API Plugin</name>
   <version>${revision}${changelist}</version>
 
-  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-
   <description>Jenkins plug-in that provides ECharts.</description>
+  <url>https://github.com/jenkinsci/echarts-api-plugin</url>
 
   <properties>
     <revision>4.4.0-9-beta1</revision>
     <changelist>-SNAPSHOT</changelist>
     <echarts.version>4.4.0</echarts.version>
 
-    <echarts-build-trends.version>0.1.0</echarts-build-trends.version>
-
     <module.name>${project.groupId}.echarts</module.name>
 
+    <echarts-build-trends.version>0.1.0</echarts-build-trends.version>
     <plugin-util-api.version>0.1.0-beta5</plugin-util-api.version>
     <jquery3-api.version>3.4.1-3-beta1</jquery3-api.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>3.55</version>
-    <relativePath />
+    <groupId>org.jvnet.hudson.plugins</groupId>
+    <artifactId>analysis-pom</artifactId>
+    <version>2.0.0-beta-2</version>
+    <relativePath/>
   </parent>
 
   <artifactId>echarts-api</artifactId>
@@ -13,64 +13,23 @@
   <packaging>hpi</packaging>
   <name>ECharts API Plugin</name>
   <version>${revision}${changelist}</version>
+
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+
   <description>Jenkins plug-in that provides ECharts.</description>
-  <url>https://github.com/jenkinsci/echarts-api-plugin</url>
 
   <properties>
     <revision>4.4.0-9-beta1</revision>
     <changelist>-SNAPSHOT</changelist>
     <echarts.version>4.4.0</echarts.version>
-    <echarts-build-trends.version>0.1.0</echarts-build-trends.version>
-    <plugin-util-api.version>0.1.0-beta5</plugin-util-api.version>
 
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jenkins.version>2.138.4</jenkins.version>
-    <java.level>8</java.level>
-    <jenkins-test-harness.version>2.59</jenkins-test-harness.version>
-    <spotbugs.failOnError>false</spotbugs.failOnError>
-    <slf4j.version>1.7.30</slf4j.version>
-    <codingstyle.version>0.3.2</codingstyle.version>
+    <echarts-build-trends.version>0.1.0</echarts-build-trends.version>
 
     <module.name>${project.groupId}.echarts</module.name>
 
-    <!-- Library Dependencies Versions -->
-    <error-prone.version>2.3.3</error-prone.version>
-    <spotbugs.annotations>3.1.12</spotbugs.annotations>
-    <commons.lang.version>3.9</commons.lang.version>
-    <eclipse-collections.version>9.2.0</eclipse-collections.version>
-    <jackson-databind.version>2.9.10.1</jackson-databind.version>
+    <plugin-util-api.version>0.1.0-beta5</plugin-util-api.version>
     <jquery3-api.version>3.4.1-3-beta1</jquery3-api.version>
 
-    <!-- Test Library Dependencies Versions -->
-    <junit.version>5.5.2</junit.version>
-    <junit-platform-launcher.version>1.5.2</junit-platform-launcher.version>
-    <mockito.version>3.2.4</mockito.version>
-    <assertj.version>3.14.0</assertj.version>
-    <archunit.version>0.13.0</archunit.version>
-    <json-unit-fluent.version>2.11.1</json-unit-fluent.version>
-
-    <!-- Maven plug-in versions -->
-    <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
-    <pmd.version>6.20.0</pmd.version>
-    <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
-    <checkstyle.version>8.28</checkstyle.version>
-    <spotbugs-maven-plugin.version>3.1.12.2</spotbugs-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-    <maven-surefire.plugin>3.0.0-M4</maven-surefire.plugin>
-    <maven-failsafe.plugin>3.0.0-M4</maven-failsafe.plugin>
-    <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
-    <depgraph-maven-plugin.version>3.3.0</depgraph-maven-plugin.version>
-    <animal-sniffer-maven-plugin.version>1.18</animal-sniffer-maven-plugin.version>
-    <maven-hpi-plugin.version>2.5</maven-hpi-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-    <pitest-maven.plugin>1.4.11</pitest-maven.plugin>
-    <pitest-maven.junit5.plugin>0.11</pitest-maven.junit5.plugin>
-    <revapi-maven-plugin.version>0.11.1</revapi-maven-plugin.version>
-    <revapi-java.version>0.19.1</revapi-java.version>
-    <assertj-assertions-generator-maven-plugin.version>2.2.0</assertj-assertions-generator-maven-plugin.version>
   </properties>
 
   <licenses>
@@ -88,26 +47,6 @@
     </developer>
   </developers>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>5.0.4</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
 
     <dependency>
@@ -116,7 +55,6 @@
       <version>${echarts.version}</version>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
@@ -134,101 +72,6 @@
       <version>${jquery3-api.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson-databind.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections-api</artifactId>
-      <version>${eclipse-collections.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections</artifactId>
-      <version>${eclipse-collections.version}</version>
-    </dependency>
-
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>${junit-platform-launcher.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-api</artifactId>
-      <version>${archunit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.archunit</groupId>
-      <artifactId>archunit-junit5-engine</artifactId>
-      <version>${archunit.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>junit-platform-engine</artifactId>
-          <groupId>org.junit.platform</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>net.javacrumbs.json-unit</groupId>
-      <artifactId>json-unit-assertj</artifactId>
-      <version>${json-unit-fluent.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>
@@ -236,7 +79,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>${maven-dependency-plugin.version}</version>
         <executions>
           <execution>
             <id>unpack-dependencies</id>
@@ -252,8 +94,8 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>${maven-resources-plugin.version}</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -274,311 +116,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin.version}</version>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Built-By>Ullrich Hafner</Built-By>
-              <Url>${project.scm.url}</Url>
-              <Jenkins-ClassFilter-Whitelisted>true</Jenkins-ClassFilter-Whitelisted>
-              <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven-surefire.plugin}</version>
-        <configuration>
-          <excludes>
-            <exclude>**/*ITest.*</exclude>
-            <exclude>**/InjectedTest.*</exclude>
-          </excludes>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.tngtech.archunit</groupId>
-            <artifactId>archunit-junit5-engine</artifactId>
-            <version>${archunit.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${maven-failsafe.plugin}</version>
-        <configuration>
-          <includes>
-            <include>**/*ITest.*</include>
-            <include>**/*InjectedTest.*</include>
-          </includes>
-          <reuseForks>false</reuseForks>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <additionalOptions>-Xdoclint:all</additionalOptions>
-          <failOnWarnings>false</failOnWarnings>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>javadoc</goal>
-            </goals>
-            <!-- As soon as possible but after required generate-sources phase -->
-            <phase>process-sources</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.pitest</groupId>
-        <artifactId>pitest-maven</artifactId>
-        <version>${pitest-maven.plugin}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-junit5-plugin</artifactId>
-            <version>${pitest-maven.junit5.plugin}</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <outputFormats>XML,HTML</outputFormats>
-          <verbose>true</verbose>
-          <targetClasses>
-            <param>io.jenkins.plugins.*</param>
-          </targetClasses>
-          <targetTests>
-            <param>io.jenkins.plugins.*</param>
-          </targetTests>
-          <excludedTestClasses>
-            <param>*ITest</param>
-          </excludedTestClasses>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${maven-checkstyle-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>run-checkstyle</id>
-            <goals>
-              <goal>checkstyle</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <failOnViolation>false</failOnViolation>
-          <configLocation>checkstyle-configuration.xml</configLocation>
-          <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <excludes>**/*Assert*.java,**/InjectedTest.java,**/Messages.java</excludes>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${checkstyle.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>edu.hm.hafner</groupId>
-            <artifactId>codingstyle</artifactId>
-            <version>${codingstyle.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>${maven-pmd-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>run-pmd</id>
-            <goals>
-              <goal>pmd</goal>
-              <goal>cpd</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <rulesets>
-            <ruleset>pmd-configuration.xml</ruleset>
-          </rulesets>
-          <excludeRoots>
-            <excludeRoot>target/generated-sources/localizer</excludeRoot>
-            <excludeRoot>target/generated-test-sources/assertj-assertions</excludeRoot>
-          </excludeRoots>
-          <excludes>
-            <exclude>**/InjectedTest.java</exclude>
-          </excludes>
-          <includeTests>true</includeTests>
-          <minimumTokens>100</minimumTokens>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-core</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-java</artifactId>
-            <version>${pmd.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>edu.hm.hafner</groupId>
-            <artifactId>codingstyle</artifactId>
-            <version>${codingstyle.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>${spotbugs-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>run-spotbugs</id>
-            <goals>
-              <goal>spotbugs</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
-        <configuration>
-          <failOnError>false</failOnError>
-          <xmlOutput>true</xmlOutput>
-          <threshold>Low</threshold>
-          <effort>Max</effort>
-          <relaxed>false</relaxed>
-          <fork>true</fork>
-          <excludeFilterFile>spotbugs-exclusion-filter.xml</excludeFilterFile>
-          <includeTests>true</includeTests>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>edu.hm.hafner</groupId>
-            <artifactId>codingstyle</artifactId>
-            <version>${codingstyle.version}</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
-        <version>${assertj-assertions-generator-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generate-assertions</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <packages>
-            <package>io.jenkins.plugins.forensics</package>
-          </packages>
-          <excludes>
-            <exclude>.*ITest</exclude>
-          </excludes>
-          <entryPointClassPackage>io.jenkins.plugins.quality.assertions</entryPointClassPackage>
-          <cleanTargetDir>true</cleanTargetDir>
-          <hierarchical>false</hierarchical>
-          <generateBddAssertions>false</generateBddAssertions>
-          <generateJUnitSoftAssertions>false</generateJUnitSoftAssertions>
-          <templates>
-            <templatesDirectory>${project.basedir}/etc/templates/</templatesDirectory>
-            <assertionsEntryPointClass>assertions_entry_point_class_template.txt</assertionsEntryPointClass>
-          </templates>
-        </configuration>
-      </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>${animal-sniffer-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>versions-maven-plugin</artifactId>
-          <version>${versions-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>display-info</id>
-              <configuration>
-                <rules>
-                  <enforceBytecodeVersion>
-                    <ignoreClasses>
-                      <!-- asm dependency from PMD contains a java9 module-info.class -->
-                      <ignoreClass>module-info</ignoreClass>
-                      <!-- Junit >= 5.3 contains some java9 classes -->
-                      <ignoreClass>**/ModuleUtils*</ignoreClass>
-                    </ignoreClasses>
-                  </enforceBytecodeVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>com.github.ferstl</groupId>
-          <artifactId>depgraph-maven-plugin</artifactId>
-          <version>${depgraph-maven-plugin.version}</version>
-          <configuration>
-            <graphFormat>puml</graphFormat>
-            <scope>runtime</scope>
-            <excludes>
-            </excludes>
-            <showVersions>true</showVersions>
-            <transitiveExcludes>
-              <exclude>*</exclude>
-            </transitiveExcludes>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.jacoco</groupId>
-          <artifactId>jacoco-maven-plugin</artifactId>
-          <version>${jacoco-maven-plugin.version}</version>
-          <configuration>
-            <includes>
-              <include>io/jenkins/plugins/**/*</include>
-            </includes>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>prepare-agent</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>report</id>
-              <phase>prepare-package</phase>
-              <goals>
-                <goal>report</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <scm>


### PR DESCRIPTION
Push configuration of static analysis tools and all common test dependencies into a new [parent pom](https://github.com/jenkinsci/analysis-pom-plugin).