### PR TITLE
Move global JS methods to an ECharts API Object to avoid name clashes

### DIFF
--- a/src/main/resources/charts/trend-chart.jelly
+++ b/src/main/resources/charts/trend-chart.jelly
@@ -36,7 +36,7 @@
             const trendProxy = <st:bind value="${it}"/>;
             trendProxy.getBuildTrendModel(function (trendModel) {
                 const useLinks = "${enableLinks}";
-                renderTrendChart('${chartId}', trendModel.responseJSON,
+                echartsJenkinsApi.renderTrendChart('${chartId}', trendModel.responseJSON,
                         (useLinks &amp;&amp; useLinks !== "false") ? true : false);
             });
       }

--- a/src/main/resources/io/jenkins/plugins/echarts-common.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts-common.jelly
@@ -11,6 +11,7 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts-common"/>
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/echarts-scope.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/zoomable-trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/pie-chart.js"/>

--- a/src/main/resources/io/jenkins/plugins/echarts-simple.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts-simple.jelly
@@ -11,6 +11,7 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts-simple"/>
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/echarts-scope.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/zoomable-trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/pie-chart.js"/>

--- a/src/main/resources/io/jenkins/plugins/echarts.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts.jelly
@@ -11,6 +11,7 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts"/>
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/echarts-scope.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/zoomable-trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/pie-chart.js"/>

--- a/src/main/webapp/js/echarts-scope.js
+++ b/src/main/webapp/js/echarts-scope.js
@@ -1,0 +1,3 @@
+function EChartsJenkinsApi() { /* Empty placeholder */ }
+
+const echartsJenkinsApi = new EChartsJenkinsApi();

--- a/src/main/webapp/js/pie-chart.js
+++ b/src/main/webapp/js/pie-chart.js
@@ -1,12 +1,12 @@
-/* global jQuery3 */
+/* global jQuery3, EChartsJenkinsApi, echartsJenkinsApi */
 jQuery3(document).ready(function () {
-    renderPieCharts(jQuery3);
+    echartsJenkinsApi.renderPieCharts(jQuery3);
 });
 
 /**
  * Renders all div elements that have the class 'echarts-pie-chart' using ECharts.
  */
-function renderPieCharts () {
+EChartsJenkinsApi.prototype.renderPieCharts = function () {
     /**
      * Renders a trend chart in the a div using ECharts.
      *

--- a/src/main/webapp/js/progress-chart.js
+++ b/src/main/webapp/js/progress-chart.js
@@ -1,12 +1,12 @@
-/* global jQuery3 */
+/* global jQuery3, EChartsJenkinsApi, echartsJenkinsApi */
 jQuery3(document).ready(function () {
-    renderProgressChart(jQuery3);
+    echartsJenkinsApi.renderProgressChart(jQuery3);
 });
 
 /**
  * Renders all div elements that have the class 'echarts-progress-chart' using ECharts.
  */
-function renderProgressChart () {
+EChartsJenkinsApi.prototype.renderProgressChart = function () {
     /**
      * Renders a trend chart in the a div using ECharts.
      *

--- a/src/main/webapp/js/trend-chart.js
+++ b/src/main/webapp/js/trend-chart.js
@@ -1,4 +1,4 @@
-/* global echarts */
+/* global echarts, EChartsJenkinsApi */
 /**
  * Renders a trend chart in the specified div using ECharts.
  *
@@ -6,7 +6,7 @@
  * @param {String} model - the line chart model
  * @param {String} withOnClickHandler - to enable clicking on the chart to see the results
  */
-function renderTrendChart (chartDivId, model, withOnClickHandler) { // eslint-disable-line no-unused-vars
+EChartsJenkinsApi.prototype.renderTrendChart = function (chartDivId, model, withOnClickHandler) { // eslint-disable-line no-unused-vars
     const chartModel = JSON.parse(model);
     const chartPlaceHolder = document.getElementById(chartDivId);
 

--- a/src/main/webapp/js/zoomable-trend-chart.js
+++ b/src/main/webapp/js/zoomable-trend-chart.js
@@ -1,4 +1,4 @@
-/* global echarts */
+/* global echarts, jQuery3, EChartsJenkinsApi */
 /**
  * Renders a trend chart in the specified div using ECharts.
  *
@@ -6,7 +6,7 @@
  * @param {String} model - the line chart model
  * @param {Function} redrawCallback - callback that will be invoked if the user toggles date or build domain
  */
-function renderZoomableTrendChart(chartDivId, model, redrawCallback) {
+EChartsJenkinsApi.prototype.renderZoomableTrendChart = function (chartDivId, model, redrawCallback) {
     const chartModel = JSON.parse(model);
     const chartPlaceHolder = document.getElementById(chartDivId);
     const chart = echarts.init(chartPlaceHolder);
@@ -90,3 +90,6 @@ function renderZoomableTrendChart(chartDivId, model, redrawCallback) {
         chart.resize();
     });
 }
+
+// Make the API change backward compatible
+renderZoomableTrendChart = echartsJenkinsApi.renderZoomableTrendChart;


### PR DESCRIPTION
Context: https://issues.jenkins-ci.org/browse/JENKINS-62625