### PR TITLE
[JENKINS-65261] Set echarts-build-trends library scope to provided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.4
-    - name: Set up JDK 8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'adopt'
+        java-version: '11'
+        check-latest: true
     - name: Cache local Maven repository
       uses: actions/cache@v2.1.4
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
       <groupId>edu.hm.hafner</groupId>
       <artifactId>echarts-build-trends</artifactId>
       <version>${echarts-build-trends.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
See https://issues.jenkins.io/browse/JENKINS-65261 for details.

- [x] Set `echarts-build-trends` scope to `provided`
- [ ] Package `eclipse-collections` into `plugin-util`
