### PR TITLE
Let y-axis of trend charts start at the minimum value and not at zero

### DIFF
--- a/src/main/webapp/js/configurable-trend-chart.js
+++ b/src/main/webapp/js/configurable-trend-chart.js
@@ -75,6 +75,7 @@ EChartsJenkinsApi.prototype.renderConfigurableZoomableTrendChart = function (cha
         }],
         yAxis: [{
             type: 'value',
+            min: 'dataMin',
             axisLabel: {
                 color: textColor
             }

--- a/src/main/webapp/js/trend-chart.js
+++ b/src/main/webapp/js/trend-chart.js
@@ -99,6 +99,7 @@ EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId,
             ],
             yAxis: [{
                 type: 'value',
+                min: 'dataMin',
                 axisLabel: {
                     color: textColor
                 }


### PR DESCRIPTION
For most charts it makes sense to let the Y-Axis start at the chart minimum value and not at zero. 

![Bildschirmfoto 2021-07-11 um 14 39 14](https://user-images.githubusercontent.com/503338/125195420-cb8c5000-e255-11eb-8477-c5628862a221.png)
