### PR TITLE
Don't use spread

### DIFF
--- a/src/main/webapp/js/chart-configuration.js
+++ b/src/main/webapp/js/chart-configuration.js
@@ -31,10 +31,7 @@ EChartsJenkinsApi.prototype.readConfiguration = function (id) {
     const specific = echartsJenkinsApi.readFromLocalStorage(id);
     const common = echartsJenkinsApi.readFromLocalStorage(trendDefaultStorageId);
 
-    return {
-        ...specific,
-        ...common
-    };
+    return Object.assign(specific, common);
 }
 
 /**


### PR DESCRIPTION
I get that you don't want to not be able to use modern JS features, but I don't have time to re-write the junit tests to use ATH / something else.

Given how small this change is I suggest we just use `Object.assign` instead

ref https://github.com/jenkinsci/junit-plugin/pull/272#issuecomment-858123397

cc @uhafner 