### PR TITLE
[JENKINS-66451] Add option to use an integer Y axis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <module.name>${project.groupId}.echarts</module.name>
 
-    <echarts-build-trends.version>3.0.0</echarts-build-trends.version>
+    <echarts-build-trends.version>3.1.0</echarts-build-trends.version>
     <plugin-util-api.version>2.4.0</plugin-util-api.version>
     <jquery3-api.version>3.6.0-2</jquery3-api.version>
     <bootstrap5-api.version>5.1.0-2</bootstrap5-api.version>

--- a/src/main/webapp/js/configurable-trend-chart.js
+++ b/src/main/webapp/js/configurable-trend-chart.js
@@ -80,7 +80,8 @@ EChartsJenkinsApi.prototype.renderConfigurableZoomableTrendChart
             min: 'dataMin',
             axisLabel: {
                 color: textColor
-            }
+            },
+            minInterval: chartModel.integerRangeAxis ? 1 : null
         }],
         series: chartModel.series
     };

--- a/src/main/webapp/js/trend-chart.js
+++ b/src/main/webapp/js/trend-chart.js
@@ -6,9 +6,9 @@
  * @param {String} enableLinks - determines if the chart is clickable. If the chart is clickable, then clicking on a
  *     chart will open the results of the selected build.
  * @param {String} configurationId - ID of the div-element that renders a configuration dialog of this trend chart.
- If this element is defined, then the trend chart will use a configuration button that
- will invoke the specified element. If your trend has no special configuration dialog
- then the ID "defaultTrendConfiguration" of the default configuration dialog should be used.
+ *     If this element is defined, then the trend chart will use a configuration button that
+ *     will invoke the specified element. If your trend has no special configuration dialog
+ *     then the ID "defaultTrendConfiguration" of the default configuration dialog should be used.
  * @param {Object} ajaxProxy - AJAX proxy of the endpoint in Jenkins Java model object
  */
 EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId, enableLinks, configurationId, ajaxProxy) {
@@ -78,7 +78,8 @@ EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId,
                 max: chartModel.rangeMax ?? 'dataMax',
                 axisLabel: {
                     color: textColor
-                }
+                },
+                minInterval: chartModel.integerRangeAxis ? 1 : null
             }
             ],
             series: chartModel.series


### PR DESCRIPTION
In order to use the option, the chart model property `chartModel.integerRangeAxis` needs to be set to `true`.

See https://github.com/uhafner/echarts-build-trends/pull/147 and [JENKINS-66451](https://issues.jenkins.io/browse/JENKINS-66451).

![Bildschirmfoto 2021-08-27 um 09 57 47](https://user-images.githubusercontent.com/503338/131126590-e19e330d-d893-4361-b9ec-cbd2bd69c15f.png)

Note: there seems to be no option to hide the fractional number where the y Axis starts.