### PR TITLE
Use a gap of 40 pixels on top of the trend chart

### DIFF
--- a/src/main/webapp/js/configurable-trend-chart.js
+++ b/src/main/webapp/js/configurable-trend-chart.js
@@ -64,7 +64,7 @@ EChartsJenkinsApi.prototype.renderConfigurableZoomableTrendChart
             left: '20',
             right: '10',
             bottom: '30',
-            top: '15%',
+            top: '40',
             containLabel: true
         },
         xAxis: [{


### PR DESCRIPTION
Using a relative value makes not much sense.