### PR TITLE
[JENKINS-66733] Do not use `??` operator that is not supported by all browsers yet

### DIFF
--- a/src/main/webapp/js/trend-chart.js
+++ b/src/main/webapp/js/trend-chart.js
@@ -22,7 +22,20 @@ EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId,
 
     function createOptions(chartModel) {
         const textColor = getComputedStyle(document.body).getPropertyValue('--text-color') || '#333';
-
+        let rangeMin;
+        if (typeof rangeMin === 'undefined' || rangeMin === null) {
+            rangeMin = 'dataMin';
+        }
+        else {
+            rangeMin = chartModel.rangeMin
+        }
+        let rangeMax;
+        if (typeof rangeMax === 'undefined' || rangeMax === null) {
+            rangeMax = 'dataMax';
+        }
+        else {
+            rangeMax = chartModel.rangeMax;
+        }
         return {
             tooltip: {
                 trigger: 'axis',
@@ -74,8 +87,8 @@ EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId,
             ],
             yAxis: [{
                 type: 'value',
-                min: chartModel.rangeMin ?? 'dataMin',
-                max: chartModel.rangeMax ?? 'dataMax',
+                min: rangeMin,
+                max: rangeMax,
                 axisLabel: {
                     color: textColor
                 },


### PR DESCRIPTION
Replace `??` with `if-else`, see [JENKINS-66733](https://issues.jenkins.io/browse/JENKINS-66733). Nullish coalescing operator `??` is only supported since Google Chrome 80 or Firefox 72.

