### PR TITLE
Update build toolchain on 5.0.2 line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.3.0</version>
+    <version>5.24.0</version>
     <relativePath />
   </parent>
 
@@ -25,8 +25,6 @@
     <module.name>${project.groupId}.echarts</module.name>
 
     <echarts-build-trends.version>2.0.0</echarts-build-trends.version>
-    <plugin-util-api.version>2.1.0</plugin-util-api.version>
-    <jquery3-api.version>3.6.0-1</jquery3-api.version>
     <eclipse-collections.version>9.2.0</eclipse-collections.version>
 
   </properties>
@@ -57,7 +55,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>${plugin-util-api.version}</version>
     </dependency>
     <dependency>
       <groupId>edu.hm.hafner</groupId>
@@ -93,6 +90,10 @@
           <groupId>org.eclipse.collections</groupId>
           <artifactId>eclipse-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -113,7 +114,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jquery3-api</artifactId>
-      <version>${jquery3-api.version}</version>
     </dependency>
 
   </dependencies>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Provides ECharts for Jenkins plugins.
+</div>


### PR DESCRIPTION
- BOM maintenance requires that everything in the BOM have its build toolchain up-to-date at all times.
- `junit` must be in the BOM, as it is one of the most popular plugins.
- As long as `junit` is in the BOM, all of its current dependencies must be in the BOM.
- As long as https://github.com/jenkinsci/junit-plugin/pull/342 remains unaddressed, `junit`'s current dependencies include `bootstrap4-api` and therefore `echarts-api` <= 5.0.2.
- As long as `echarts-api` <= 5.0.2 must remain in the BOM, its build toolchain must be kept up-to-date.

commit de25291083107967a29e5fd9ca3933fbea0c0990 in this PR is based on top of `echarts-api` 5.0.2-1. It updates the build toolchain. I am asking that we backport these build toolchain updates to the 5.0.2 line and release 5.0.2-2. This would allow us to update the 5.0.2 version of `echarts-api` in the BOM, even without https://github.com/jenkinsci/junit-plugin/pull/342, and unblock my other BOM work in the short term. For instructions on how to do a backport, see: https://gist.github.com/jglick/86a30894446ed38f918050c1180483e2