### PR TITLE
Use `rangeMin` and `rangeMax` in all charts if defined in model (instead of using `dataMin` by default)

### DIFF
--- a/src/main/webapp/js/configurable-trend-chart.js
+++ b/src/main/webapp/js/configurable-trend-chart.js
@@ -77,7 +77,8 @@ EChartsJenkinsApi.prototype.renderConfigurableZoomableTrendChart
         }],
         yAxis: [{
             type: 'value',
-            min: 'dataMin',
+            min: chartModel.rangeMin ?? 'dataMin',
+            max: chartModel.rangeMax ?? 'dataMax',
             axisLabel: {
                 color: textColor
             },

--- a/src/main/webapp/js/trend-chart.js
+++ b/src/main/webapp/js/trend-chart.js
@@ -22,20 +22,6 @@ EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId,
 
     function createOptions(chartModel) {
         const textColor = getComputedStyle(document.body).getPropertyValue('--text-color') || '#333';
-        let rangeMin;
-        if (typeof rangeMin === 'undefined' || rangeMin === null) {
-            rangeMin = 'dataMin';
-        }
-        else {
-            rangeMin = chartModel.rangeMin
-        }
-        let rangeMax;
-        if (typeof rangeMax === 'undefined' || rangeMax === null) {
-            rangeMax = 'dataMax';
-        }
-        else {
-            rangeMax = chartModel.rangeMax;
-        }
         return {
             tooltip: {
                 trigger: 'axis',
@@ -87,8 +73,8 @@ EChartsJenkinsApi.prototype.renderConfigurableTrendChart = function (chartDivId,
             ],
             yAxis: [{
                 type: 'value',
-                min: rangeMin,
-                max: rangeMax,
+                min: chartModel.rangeMin ?? 'dataMin',
+                max: chartModel.rangeMax ?? 'dataMax',
                 axisLabel: {
                     color: textColor
                 },


### PR DESCRIPTION
Using rangeMin and rangeMax from chartModel instead of using 'dataMin' by default in yAxis in **configurable-trend-chart.js** and **trend-chart.js**.

I have already submitted an issue in the [echarts-build-trends](https://github.com/uhafner/echarts-build-trends/issues/206) repository. I have looked at this again more closely and find out, that the rangeMin and rangeMax property is ignored for the configurable trend charts. 

I tested the changes locally and using the following setup now:

```
/* Use 'dataMax' as range max.
 model.setRangeMax(Math.max(
        Math.max(createRangeMaxFor(dataSet, ReportSeriesBuilder.ACCURATE),
                createRangeMaxFor(dataSet, ReportSeriesBuilder.MANUALLY)),
        createRangeMaxFor(dataSet, ReportSeriesBuilder.INCORRECT)) + 10);
 */

// Use zero instead of 'dataMin' range min.
model.setRangeMin(0);
```

and setting the model with:

```
echartsJenkinsApi.renderConfigurableZoomableTrendChart
```

Result:

<img width="586" alt="Bildschirmfoto 2022-06-08 um 13 28 44" src="https://user-images.githubusercontent.com/26878018/172605655-10472b3b-5279-4ac5-8fb1-cb37c00e42df.png">

The same problem was observed for the pre defined job trend charts. I also updated the js file for the trend-result. 

Result:

<img width="1025" alt="Bildschirmfoto 2022-06-08 um 14 10 58" src="https://user-images.githubusercontent.com/26878018/172613437-4919ea5d-7a04-47cc-976d-327d7fde17f0.png">



- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

