### PR TITLE
escape js meta characters if using jQuery3

### DIFF
--- a/src/main/resources/io/jenkins/plugins/echarts-common.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts-common.jelly
@@ -20,5 +20,6 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts-common"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/configurable-trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/pie-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/progress-chart.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/escapeMetaCharacters.js"/>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/echarts-simple.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts-simple.jelly
@@ -20,5 +20,6 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts-simple"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/configurable-trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/pie-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/progress-chart.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/escapeMetaCharacters.js"/>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/echarts.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts.jelly
@@ -20,5 +20,6 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/configurable-trend-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/pie-chart.js"/>
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/progress-chart.js"/>
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/escapeMetaCharacters.js"/>
 
 </j:jelly>

--- a/src/main/webapp/js/escapeMetaCharacters.js
+++ b/src/main/webapp/js/escapeMetaCharacters.js
@@ -1,0 +1,3 @@
+function escapeMetaCharacters(string) {
+    return string.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/src/main/webapp/js/pie-chart.js
+++ b/src/main/webapp/js/pie-chart.js
@@ -35,7 +35,7 @@ jQuery3(document).ready(function () {
                 }
             }
 
-            const chartPlaceHolder = jQuery3("#" + chartDivId);
+            const chartPlaceHolder = jQuery3("#" + escapeMetaCharacters(chartDivId));
             const model = JSON.parse(chartPlaceHolder.attr('data-chart-model'));
             const title = chartPlaceHolder.attr('data-title');
             const chartDiv = chartPlaceHolder[0];

--- a/src/main/webapp/js/progress-chart.js
+++ b/src/main/webapp/js/progress-chart.js
@@ -10,7 +10,7 @@ jQuery3(document).ready(function () {
          * @param {String} chartDivId - the ID of the div where the chart should be shown in
          */
         function renderProgressChart(chartDivId) {
-            const chartPlaceHolder = jQuery3("#" + chartDivId);
+            const chartPlaceHolder = jQuery3("#" + escapeMetaCharacters(chartDivId));
             const model = JSON.parse(chartPlaceHolder.attr('data-chart-model'));
             const title = chartPlaceHolder.attr('data-title');
             const tooltip = chartPlaceHolder.attr('data-tooltip');


### PR DESCRIPTION
Pie and Progress charts are not rendered if the chartDivId contains js meta characters like brackets:

![174252791-49cd38cf-49ec-4738-9b1f-28d4b0924947](https://user-images.githubusercontent.com/26878018/174321276-62780e78-004d-4b5b-9cce-7555592ae74a.png)

[pie-chart.js](https://github.com/jenkinsci/echarts-api-plugin/blob/master/src/main/webapp/js/pie-chart.js) and [progress-chart.js](https://github.com/jenkinsci/echarts-api-plugin/blob/master/src/main/webapp/js/progress-chart.js) are using `jQuery3` to fetch the document element by id. All others use `document.getElementById()`.

Obviously the characters are not automatically escaped by jQuery. 

After escaping the characters, the charts are rendered:

![Bildschirmfoto 2022-06-17 um 16 49 13](https://user-images.githubusercontent.com/26878018/174322043-1e56d9e8-c3eb-470b-bc00-120c87d0af87.png)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
