### PR TITLE
Remove obsolete Eclipse collections dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,6 @@
 
     <module.name>${project.groupId}.echarts</module.name>
 
-    <eclipse-collections.version>9.2.0</eclipse-collections.version>
-
     <echarts-build-trends.version>4.3.0</echarts-build-trends.version>
 
   </properties>
@@ -45,16 +43,6 @@
   </developers>
 
   <dependencies>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections-api</artifactId>
-      <version>${eclipse-collections.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections</artifactId>
-      <version>${eclipse-collections.version}</version>
-    </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>


### PR DESCRIPTION
The dependency is not required and all important consumers do not use the API anymore.