### PR TITLE
Refresh trend charts when system dark mode settings fire an event

### DIFF
--- a/src/main/webapp/js/echarts-api.js
+++ b/src/main/webapp/js/echarts-api.js
@@ -501,6 +501,11 @@ const echartsJenkinsApi = {
             document.addEventListener(redrawChartEvent, function () {
                 renderAsynchronously(chart);
             });
+            if (window.getThemeManagerProperty && window.isSystemRespectingTheme) {
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                    renderAsynchronously(chart);
+                });
+            }
 
             getConfigurationDialog().addEventListener("hidden.bs.modal", function () {
                 const configuration = echartsJenkinsApi.readConfiguration(localStorageId);


### PR DESCRIPTION
Toggling dark and light mode required a redrawing of all trend charts since the colors need to be adapted.
