### PR TITLE
Add support for y-axis zoom in renderConfigurableZoomableTrendChart()

### DIFF
--- a/src/main/webapp/js/echarts-api.js
+++ b/src/main/webapp/js/echarts-api.js
@@ -227,8 +227,9 @@ const echartsJenkinsApi = {
      * @param {String} settingsDialogId - the optional ID of the div that provides a settings dialog (might be set to null
      *     if there is no such dialog)
      * @param {Function} chartClickedEventHandler - the optional event handler that receives click events
+     * @param {Boolean} allowYAxisZoom - Allow zooming on the y-axis
      */
-    renderConfigurableZoomableTrendChart: function (chartDivId, model, settingsDialogId, chartClickedEventHandler) {
+    renderConfigurableZoomableTrendChart: function (chartDivId, model, settingsDialogId, chartClickedEventHandler, allowYAxisZoom = false) {
         const themedModel = echartsJenkinsApi.resolveJenkinsColors(model);
         const chartModel = JSON.parse(themedModel);
         const chartPlaceHolder = document.getElementById(chartDivId);
@@ -237,6 +238,35 @@ const echartsJenkinsApi = {
 
         const textColor = getComputedStyle(document.body).getPropertyValue('--text-color') || '#333';
         const showSettings = document.getElementById(settingsDialogId);
+
+        function getDataZoomOptions(allowYAxisZoom) {
+            var dataZoomOptions = [
+                {
+                    type: 'inside'
+                },
+                {
+                    type: 'slider',
+                    height: 25,
+                    bottom: 5,
+                    moveHandleSize: 5,
+                    xAxisIndex: [0],
+                    filterMode: 'filter',
+                }
+            ];
+
+            if (allowYAxisZoom) {
+                dataZoomOptions.push({
+                    type: 'slider',
+                    width: 25,
+                    right: 5,
+                    moveHandleSize: 5,
+                    yAxisIndex: [0],
+                    filterMode: 'empty'
+                });
+            }
+
+            return dataZoomOptions;
+        };
 
         const options = {
             tooltip: {
@@ -261,16 +291,7 @@ const echartsJenkinsApi = {
                     }
                 }
             },
-            dataZoom: [
-                {
-                    type: 'inside'
-                },
-                {
-                    type: 'slider',
-                    height: 25,
-                    bottom: 5,
-                    moveHandleSize: 5
-                }],
+            dataZoom: getDataZoomOptions(allowYAxisZoom),
             legend: {
                 orient: 'horizontal',
                 type: 'scroll',
@@ -282,7 +303,7 @@ const echartsJenkinsApi = {
             },
             grid: {
                 left: '20',
-                right: '10',
+                right: allowYAxisZoom ? '40' : '10',
                 bottom: '35',
                 top: '40',
                 containLabel: true


### PR DESCRIPTION
Add an optional argument (`allowYAxisZoom`) to `renderConfigurableZoomableTrendChart()` to enable y-axis zooming via the [dataZoom](https://echarts.apache.org/en/option.html#dataZoom) e-charts option.

### Testing done

Verified the chart with, and without the `allowYAxisZoom` set to `true`. See screenshots below.
Using the y-axis slider correctly zooms the chart.

`allowYAxisZoom = false`
![image](https://github.com/jenkinsci/echarts-api-plugin/assets/45196583/b20f6bed-e3a3-4bb8-bb8d-abc104395b7e)

`allowYAxisZoom = true`
![image](https://github.com/jenkinsci/echarts-api-plugin/assets/45196583/42c1604e-03f8-47f6-b2c7-c841bd6d1f4a)

[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

