### PR TITLE
Accessibility: labels should match input IDs

### DIFF
--- a/src/main/resources/charts/chart-setup.jelly
+++ b/src/main/resources/charts/chart-setup.jelly
@@ -38,14 +38,14 @@
               </label>
             </div>
             <div class="mb-3">
-              <label for="builds" class="form-label">Maximum number of builds to consider</label>
+              <label for="builds-${id}" class="form-label">Maximum number of builds to consider</label>
               <input type="number" min="2" class="form-control" id="builds-${id}" required="true"/>
               <div id="builds-help-${id}" class="form-text">If set to a value less than 2 then all builds will be
                 considered.
               </div>
             </div>
             <div class="mb-3">
-              <label for="days" class="form-label">Maximum number of days to look into the past</label>
+              <label for="days-${id}" class="form-label">Maximum number of days to look into the past</label>
               <input type="number" min="0" class="form-control" id="days-${id}" required="true"/>
               <div id="days-help-${id}" class="form-text">If set to a value less than 1 then builds of all days are
                 considered.


### PR DESCRIPTION
Make sure label's `for` attribute matches input's `id` so that the browser understands they are connected (avoids accessibility warnings in Chrome dev tools)

### Testing done
Verified that Chrome warning is gone and clicking labels focuses inputs.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```
