### PR TITLE
Convert `oklch` colors to HEX values

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "doc": "doc"
   },
   "dependencies": {
-    "echarts": "5.6.0"
+    "echarts": "5.6.0",
+    "colorjs.io": "0.5.2"
   },
   "devDependencies": {
     "remark-cli": "12.0.1",

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,16 @@
                   <directory>${project.basedir}/node_modules/echarts/dist</directory>
                   <filtering>false</filtering>
                 </resource>
+                <resource>
+                  <directory>${project.basedir}/node_modules/colorjs.io/dist</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>color.global.js</include>
+                    <include>color.global.js.map</include>
+                    <include>color.global.min.js</include>
+                    <include>color.global.min.js.map</include>
+                  </includes>
+                </resource>
               </resources>
             </configuration>
           </execution>

--- a/src/main/resources/io/jenkins/plugins/echarts.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts.jelly
@@ -8,6 +8,7 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts"/>
   ${h.initPageVariables(context)}
 
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/echarts.min.js" />
+  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/color.global.min.js"/>
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 

--- a/src/main/webapp/js/echarts-api.js
+++ b/src/main/webapp/js/echarts-api.js
@@ -31,7 +31,14 @@ const echartsJenkinsApi = {
      * @return {string|string}
      */
     resolveJenkinsColor: function (colorName) {
-        return getComputedStyle(document.body).getPropertyValue(colorName) || '#333';
+        const color = getComputedStyle(document.body).getPropertyValue(colorName) || '#333';
+
+        try {
+            return new Color(color).to("sRGB").toString({format: "hex"});
+        }
+        catch (e) {
+            return '#333';
+        }
     },
 
     /**


### PR DESCRIPTION
ECharts does not support `oklch` yet. So we need to replace all Jenkins colors by plain RGB HEX values before setting the chart options.

See [JENKINS-75242](https://issues.jenkins.io/browse/JENKINS-75242).

Supersedes #380 