### PR TITLE
Use `{color: inherit}` for emphasis

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "doc": "doc"
   },
   "dependencies": {
-    "echarts": "5.6.0",
-    "colorjs.io": "0.5.2"
+    "echarts": "5.6.0"
   },
   "devDependencies": {
     "remark-cli": "12.0.1",

--- a/pom.xml
+++ b/pom.xml
@@ -152,16 +152,6 @@
                   <directory>${project.basedir}/node_modules/echarts/dist</directory>
                   <filtering>false</filtering>
                 </resource>
-                <resource>
-                  <directory>${project.basedir}/node_modules/colorjs.io/dist</directory>
-                  <filtering>false</filtering>
-                  <includes>
-                    <include>color.global.js</include>
-                    <include>color.global.js.map</include>
-                    <include>color.global.min.js</include>
-                    <include>color.global.min.js.map</include>
-                  </includes>
-                </resource>
               </resources>
             </configuration>
           </execution>

--- a/src/main/resources/io/jenkins/plugins/echarts.jelly
+++ b/src/main/resources/io/jenkins/plugins/echarts.jelly
@@ -8,7 +8,6 @@ Use it like <st:adjunct includes="io.jenkins.plugins.echarts"/>
   ${h.initPageVariables(context)}
 
   <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/echarts.min.js" />
-  <script type="text/javascript" src="${resURL}/plugin/echarts-api/js/color.global.min.js"/>
 
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
 

--- a/src/main/webapp/js/echarts-api.js
+++ b/src/main/webapp/js/echarts-api.js
@@ -31,14 +31,7 @@ const echartsJenkinsApi = {
      * @return {string|string}
      */
     resolveJenkinsColor: function (colorName) {
-        const color = getComputedStyle(document.body).getPropertyValue(colorName) || '#333';
-
-        try {
-            return new Color(color).to("sRGB").toString({format: "hex"});
-        }
-        catch (e) {
-            return '#333';
-        }
+        return getComputedStyle(document.body).getPropertyValue(colorName) || '#333';
     },
 
     /**
@@ -294,6 +287,15 @@ const echartsJenkinsApi = {
             return dataZoomOptions;
         }
 
+        const inheritColors = {
+            focus: 'series',
+            color: 'inherit',
+            areaStyle: {color: 'inherit'}
+        };
+        chartModel.series.forEach(seriesElement => {
+            seriesElement.emphasis = inheritColors;
+        });
+
         const options = {
             tooltip: {
                 trigger: 'axis',
@@ -392,6 +394,15 @@ const echartsJenkinsApi = {
         }
 
         function createOptions(chartModel) {
+            const inheritColors = {
+                focus: 'series',
+                color: 'inherit',
+                areaStyle: {color: 'inherit'}
+            };
+            chartModel.series.forEach(seriesElement => {
+                seriesElement.emphasis = inheritColors;
+            });
+
             const textColor = getComputedStyle(document.body).getPropertyValue('--text-color') || '#333';
             return {
                 tooltip: {
@@ -643,6 +654,9 @@ const echartsJenkinsApi = {
                         color: textColor
                     }
                 },
+                emphasis: {
+                    color: 'inherit'
+                },
                 series: [{
                     type: 'pie',
                     radius: ['30%', '70%'],
@@ -656,6 +670,9 @@ const echartsJenkinsApi = {
                         emphasis: {
                             show: false
                         }
+                    },
+                    emphasis: {
+                        color: 'inherit'
                     },
                     labelLine: {
                         normal: {


### PR DESCRIPTION
This is a much better fix for [JENKINS-75242](https://issues.jenkins.io/browse/JENKINS-75242), see discussion in https://github.com/apache/echarts/issues/20757.

This PR basically replaces https://github.com/jenkinsci/echarts-api-plugin/pull/383
