### PR TITLE
Improve Trend Chart navigation behaviour 

### DIFF
--- a/src/main/webapp/js/echarts-api.js
+++ b/src/main/webapp/js/echarts-api.js
@@ -506,7 +506,15 @@ const echartsJenkinsApi = {
                             }
 
                             if (selectedBuild > 0) {
-                                window.location.assign(selectedBuild + '/' + urlName);
+                                const buildUrl = selectedBuild + '/' + urlName;
+                                const evt = params.event;
+                                if (evt && (evt.ctrlKey || evt.metaKey || evt.button === 1)) {
+                                    window.open(buildUrl, '_blank');
+                                } else if (evt && evt.shiftKey) {
+                                    window.open(buildUrl, '_newWindow');
+                                } else {
+                                    window.location.assign(buildUrl)
+                                }
                             }
                         }
                     })

--- a/src/main/webapp/js/echarts-api.js
+++ b/src/main/webapp/js/echarts-api.js
@@ -508,7 +508,7 @@ const echartsJenkinsApi = {
                             if (selectedBuild > 0) {
                                 const buildUrl = selectedBuild + '/' + urlName;
                                 const evt = params.event;
-                                if (evt && (evt.ctrlKey || evt.metaKey || evt.button === 1)) {
+                                if (evt && (evt.ctrlKey || evt.metaKey)) {
                                     window.open(buildUrl, '_blank');
                                 } else if (evt && evt.shiftKey) {
                                     window.open(buildUrl, '_newWindow');


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR introduces the following changes when users click on the build numbers/coordinates in the trend chart : 

- cmd/ctrl+click - Opens the build's static result on a new tab while keeping the current tab in focus.
- shift+click - Opens the build's static result on a new window and shifts focus to the new window.

See [JENKINS-64581](https://issues.jenkins.io/browse/JENKINS-64581).
### Testing done
Tested this feature on: 
Jenkins 2.505
Warnings Plugin 12.5.0
macOS 10.15.7
Chrome 135.0.0.0
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
